### PR TITLE
Configure Bazel build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ prof.out
 .ipynb_checkpoints/
 __pycache__
 ~*.xlsx
+bazel*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,5 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix checklist
+# gazelle:proto disable_global
+gazelle(name = "gazelle")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,43 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("//:repositories.bzl", "go_repositories")
+
+# gazelle:repository_macro repositories.bzl%go_repositories
+go_repositories()
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.16")
+
+gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
+    strip_prefix = "protobuf-3.11.4",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/cmd/benchmark_incremental/BUILD.bazel
+++ b/cmd/benchmark_incremental/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "benchmark_incremental_lib",
+    srcs = ["benchmark_incremental.go"],
+    importpath = "checklist/cmd/benchmark_incremental",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+        "@tools_gotest//assert",
+    ],
+)
+
+go_binary(
+    name = "benchmark_incremental",
+    embed = [":benchmark_incremental_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/benchmark_initial/BUILD.bazel
+++ b/cmd/benchmark_initial/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "benchmark_initial_lib",
+    srcs = ["benchmark_initial.go"],
+    importpath = "checklist/cmd/benchmark_initial",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+        "@tools_gotest//assert",
+    ],
+)
+
+go_binary(
+    name = "benchmark_initial",
+    embed = [":benchmark_initial_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/benchmark_trace/BUILD.bazel
+++ b/cmd/benchmark_trace/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "benchmark_trace_lib",
+    srcs = ["benchmark_trace.go"],
+    importpath = "checklist/cmd/benchmark_trace",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//testing",
+    ],
+)
+
+go_binary(
+    name = "benchmark_trace",
+    embed = [":benchmark_trace_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/benchmark_updates/BUILD.bazel
+++ b/cmd/benchmark_updates/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "benchmark_updates_lib",
+    srcs = ["benchmark_updates.go"],
+    importpath = "checklist/cmd/benchmark_updates",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+        "@tools_gotest//assert",
+    ],
+)
+
+go_binary(
+    name = "benchmark_updates",
+    embed = [":benchmark_updates_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/rpc_client/BUILD.bazel
+++ b/cmd/rpc_client/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "rpc_client_lib",
+    srcs = ["rpc_client.go"],
+    importpath = "checklist/cmd/rpc_client",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+    ],
+)
+
+go_binary(
+    name = "rpc_client",
+    embed = [":rpc_client_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/rpc_server/BUILD.bazel
+++ b/cmd/rpc_server/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "rpc_server_lib",
+    srcs = ["rpc_server.go"],
+    importpath = "checklist/cmd/rpc_server",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//rpc",
+        "//safebrowsing",
+    ],
+)
+
+go_binary(
+    name = "rpc_server",
+    embed = [":rpc_server_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sbproxy/BUILD.bazel
+++ b/cmd/sbproxy/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "sbproxy_lib",
+    srcs = ["sbproxy.go"],
+    importpath = "checklist/cmd/sbproxy",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//safebrowsing",
+        "//updatable",
+        "@com_github_golang_protobuf//proto",
+        "@com_github_golang_protobuf//ptypes/duration",
+    ],
+)
+
+go_binary(
+    name = "sbproxy",
+    embed = [":sbproxy_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sbtunnel/BUILD.bazel
+++ b/cmd/sbtunnel/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "sbtunnel_lib",
+    srcs = ["sbtunnel.go"],
+    importpath = "checklist/cmd/sbtunnel",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//safebrowsing",
+        "@com_github_golang_protobuf//proto",
+    ],
+)
+
+go_binary(
+    name = "sbtunnel",
+    embed = [":sbtunnel_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/stress/BUILD.bazel
+++ b/cmd/stress/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "stress_lib",
+    srcs = [
+        "answer_load_gen.go",
+        "hint_load_gen.go",
+        "key_update_load_gen.go",
+        "loadtype_enumer.go",
+        "stress.go",
+        "user_load_gen.go",
+    ],
+    importpath = "checklist/cmd/stress",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+        "@com_github_paulbellamy_ratecounter//:ratecounter",
+        "@com_github_zserge_metric//:metric",
+    ],
+)
+
+go_binary(
+    name = "stress",
+    embed = [":stress_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "driver",
+    srcs = [
+        "flags.go",
+        "pir_rpc_proxy.go",
+        "pir_server_driver.go",
+        "profiler.go",
+        "test_util.go",
+        "trace.go",
+        "types.go",
+    ],
+    importpath = "checklist/driver",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pir",
+        "//rpc",
+        "//updatable",
+        "@com_github_ugorji_go_codec//:codec",
+    ],
+)
+
+go_test(
+    name = "driver_test",
+    srcs = ["driver_test.go"],
+    embed = [":driver"],
+    deps = [
+        "//pir",
+        "//rpc",
+        "//safebrowsing",
+        "//updatable",
+        "@com_github_ugorji_go_codec//:codec",
+        "@tools_gotest//assert",
+    ],
+)

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "example_lib",
+    srcs = ["main.go"],
+    importpath = "checklist/example",
+    visibility = ["//visibility:private"],
+    deps = ["//pir"],
+)
+
+go_binary(
+    name = "example",
+    embed = [":example_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/gazelle.sh
+++ b/gazelle.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Gazelle can automatically generate and maintain bazel BUILD files and dependencies.
+bazel run //:gazelle -- update-repos --from_file=go.mod -to_macro=repositories.bzl%go_repositories
+bazel run //:gazelle -- fix
+
+# gazelle does not yet support aliasing in go.mod
+# we need to manually carry on that aliasing ourselves.
+sed "s/@com_github_dkales_dpf_go\/\/dpf:go_default_library/\/\/modules\/dpf-go\/dpf:dpf/g" -i modules/dpf-go/BUILD.bazel pir/BUILD.bazel
+sed "s/checklist\/modules\/dpf-go\/dpf/github.com\/dkales\/dpf-go\/dpf/g" -i modules/dpf-go/dpf/BUILD.bazel
+
+# link against lstdc++ instead of -static-libstdc++.
+sed "s/-static-libstdc++/-lstdc++/g" -i psetggm/BUILD.bazel

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -24,6 +25,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rocketlaunchr/https-go v0.0.0-20200218083740-ba6c48f29f4d h1:bL0c7wxznxDDQ+ebCpGN5T20ATeYDXedomXbQHwFwHA=
 github.com/rocketlaunchr/https-go v0.0.0-20200218083740-ba6c48f29f4d/go.mod h1:kDbnFcjPe/2KqPfycPSq0Ripnddx0DtCC2M1k95myWQ=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -53,15 +55,19 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
 golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/modules/dpf-go/BUILD.bazel
+++ b/modules/dpf-go/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "dpf-go_lib",
+    srcs = ["dpf_main.go"],
+    importpath = "checklist/modules/dpf-go",
+    visibility = ["//visibility:private"],
+    deps = ["//modules/dpf-go/dpf:dpf"],
+)
+
+go_binary(
+    name = "dpf-go",
+    embed = [":dpf-go_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/dpf-go/dpf/BUILD.bazel
+++ b/modules/dpf-go/dpf/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "dpf",
+    srcs = [
+        "aes.go",
+        "aes_amd64.s",
+        "aes_arm64.s",
+        "dpf.go",
+    ],
+    importpath = "github.com/dkales/dpf-go/dpf",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "dpf_test",
+    srcs = ["dpf_test.go"],
+    embed = [":dpf"],
+)

--- a/pir/BUILD.bazel
+++ b/pir/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "pir",
+    srcs = [
+        "crypto_rand.go",
+        "pir.go",
+        "pir_dpf.go",
+        "pir_matrix.go",
+        "pir_non_private.go",
+        "pir_punc.go",
+        "pir_reader.go",
+        "pirtype_enumer.go",
+        "pset.go",
+        "pset_ggm.go",
+        "static_db.go",
+        "test_util.go",
+    ],
+    importpath = "checklist/pir",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//psetggm",
+        "//modules/dpf-go/dpf:dpf",
+        "@com_github_lukechampine_fastxor//:fastxor",
+    ],
+)
+
+go_test(
+    name = "pir_test",
+    srcs = [
+        "pir_test.go",
+        "pset_test.go",
+    ],
+    embed = [":pir"],
+    deps = [
+        "//psetggm",
+        "@tools_gotest//assert",
+    ],
+)

--- a/psetggm/BUILD.bazel
+++ b/psetggm/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "psetggm",
+    srcs = [
+        "AES.cpp",
+        "AES.h",
+        "Defines.cpp",
+        "Defines.h",
+        "answer.cpp",
+        "answer.h",
+        "flat_hash_map.hpp",
+        "gsl-lite.hpp",
+        "intrinsics.h",
+        "pset_ggm.cpp",
+        "pset_ggm.h",
+        "pset_ggm_c.go",
+        "sse2neon.h",
+        "xor.cpp",
+        "xor.h",
+    ],
+    cgo = True,
+    clinkopts = ["-lstdc++"],
+    cxxopts = select({
+        "@io_bazel_rules_go//go/platform:amd64": [
+            "-msse2 -msse -march=native -maes -Ofast -std=c++11",
+        ],
+        "@io_bazel_rules_go//go/platform:arm64": [
+            "-march=armv8-a+fp+simd+crypto+crc -Ofast -std=c++11",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "checklist/psetggm",
+    visibility = ["//visibility:public"],
+)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,189 @@
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def go_repositories():
+    go_repository(
+        name = "com_github_burntsushi_xgb",
+        importpath = "github.com/BurntSushi/xgb",
+        sum = "h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=",
+        version = "v0.0.0-20160522181843-27f122750802",
+    )
+    go_repository(
+        name = "com_github_davecgh_go_spew",
+        importpath = "github.com/davecgh/go-spew",
+        sum = "h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=",
+        version = "v1.1.0",
+    )
+    go_repository(
+        name = "com_github_elliotchance_orderedmap",
+        importpath = "github.com/elliotchance/orderedmap",
+        sum = "h1:wZtfeEONCbx6in1CZyE6bELEt/vFayMvsxqI5SgsR+A=",
+        version = "v1.4.0",
+    )
+    go_repository(
+        name = "com_github_golang_protobuf",
+        importpath = "github.com/golang/protobuf",
+        sum = "h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=",
+        version = "v1.4.3",
+    )
+    go_repository(
+        name = "com_github_google_go_cmp",
+        importpath = "github.com/google/go-cmp",
+        sum = "h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=",
+        version = "v0.4.0",
+    )
+    go_repository(
+        name = "com_github_lukechampine_fastxor",
+        importpath = "github.com/lukechampine/fastxor",
+        sum = "h1:P5ymLbODejVbeR9o+TCXMmxHhiCfpqWhEFcm5EF6Y0A=",
+        version = "v0.0.0-20210322201628-b664bed5a5cc",
+    )
+    go_repository(
+        name = "com_github_paulbellamy_ratecounter",
+        importpath = "github.com/paulbellamy/ratecounter",
+        sum = "h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=",
+        version = "v0.2.0",
+    )
+    go_repository(
+        name = "com_github_pkg_errors",
+        importpath = "github.com/pkg/errors",
+        sum = "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=",
+        version = "v0.9.1",
+    )
+    go_repository(
+        name = "com_github_pmezard_go_difflib",
+        importpath = "github.com/pmezard/go-difflib",
+        sum = "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_rocketlaunchr_https_go",
+        importpath = "github.com/rocketlaunchr/https-go",
+        sum = "h1:bL0c7wxznxDDQ+ebCpGN5T20ATeYDXedomXbQHwFwHA=",
+        version = "v0.0.0-20200218083740-ba6c48f29f4d",
+    )
+    go_repository(
+        name = "com_github_stretchr_objx",
+        importpath = "github.com/stretchr/objx",
+        sum = "h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=",
+        version = "v0.1.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_testify",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=",
+        version = "v1.7.0",
+    )
+    go_repository(
+        name = "com_github_ugorji_go",
+        importpath = "github.com/ugorji/go",
+        sum = "h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=",
+        version = "v1.2.4",
+    )
+    go_repository(
+        name = "com_github_ugorji_go_codec",
+        importpath = "github.com/ugorji/go/codec",
+        sum = "h1:C5VurWRRCKjuENsbM6GYVw8W++WVW9rSxoACKIvxzz8=",
+        version = "v1.2.4",
+    )
+    go_repository(
+        name = "com_github_zserge_metric",
+        importpath = "github.com/zserge/metric",
+        sum = "h1:IkYtSU/cSx7gnLZTJHrmblRtR3D4JVIvX7nnKELJT5U=",
+        version = "v0.1.0",
+    )
+    go_repository(
+        name = "in_gopkg_check_v1",
+        importpath = "gopkg.in/check.v1",
+        sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",
+        version = "v0.0.0-20161208181325-20d25e280405",
+    )
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=",
+        version = "v3.0.0-20200313102051-9f266ea9e77c",
+    )
+    go_repository(
+        name = "org_golang_google_protobuf",
+        importpath = "google.golang.org/protobuf",
+        sum = "h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=",
+        version = "v1.23.0",
+    )
+    go_repository(
+        name = "org_golang_x_crypto",
+        importpath = "golang.org/x/crypto",
+        sum = "h1:B2n+Zi5QeYRDAEodEu72OS36gmTWjgpXr2+cWcBW90o=",
+        version = "v0.0.0-20210506145944-38f3c27a63bf",
+    )
+    go_repository(
+        name = "org_golang_x_exp",
+        importpath = "golang.org/x/exp",
+        sum = "h1:estk1glOnSVeJ9tdEZZc5mAMDZk5lNJNyJ6DvrBkTEU=",
+        version = "v0.0.0-20190731235908-ec7cb31e5a56",
+    )
+    go_repository(
+        name = "org_golang_x_image",
+        importpath = "golang.org/x/image",
+        sum = "h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=",
+        version = "v0.0.0-20190802002840-cff245a6509b",
+    )
+    go_repository(
+        name = "org_golang_x_mobile",
+        importpath = "golang.org/x/mobile",
+        sum = "h1:h+GZ3ubjuWaQjGe8owMGcmMVCqs0xYJtRG5y2bpHaqU=",
+        version = "v0.0.0-20210220033013-bdb1ca9a1e08",
+    )
+    go_repository(
+        name = "org_golang_x_mod",
+        importpath = "golang.org/x/mod",
+        sum = "h1:ePuNC7PZ6O5BzgPn9bZayERXBdfZjUYoXEf5BTfDfh8=",
+        version = "v0.1.1-0.20191209134235-331c550502dd",
+    )
+    go_repository(
+        name = "org_golang_x_net",
+        importpath = "golang.org/x/net",
+        sum = "h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=",
+        version = "v0.0.0-20210226172049-e18ecbb05110",
+    )
+    go_repository(
+        name = "org_golang_x_sync",
+        importpath = "golang.org/x/sync",
+        sum = "h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=",
+        version = "v0.0.0-20190423024810-112230192c58",
+    )
+    go_repository(
+        name = "org_golang_x_sys",
+        importpath = "golang.org/x/sys",
+        sum = "h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=",
+        version = "v0.0.0-20210503173754-0981d6026fa6",
+    )
+    go_repository(
+        name = "org_golang_x_term",
+        importpath = "golang.org/x/term",
+        sum = "h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=",
+        version = "v0.0.0-20201126162022-7de9c90e9dd1",
+    )
+    go_repository(
+        name = "org_golang_x_text",
+        importpath = "golang.org/x/text",
+        sum = "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
+        version = "v0.3.3",
+    )
+    go_repository(
+        name = "org_golang_x_tools",
+        importpath = "golang.org/x/tools",
+        sum = "h1:yBHHx+XZqXJBm6Exke3N7V9gnlsyXxoCPEb1yVenjfk=",
+        version = "v0.0.0-20200117012304-6edc0a871e69",
+    )
+    go_repository(
+        name = "org_golang_x_xerrors",
+        importpath = "golang.org/x/xerrors",
+        sum = "h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=",
+        version = "v0.0.0-20191204190536-9bdfabe68543",
+    )
+    go_repository(
+        name = "tools_gotest",
+        importpath = "gotest.tools",
+        sum = "h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=",
+        version = "v2.2.0+incompatible",
+    )

--- a/rpc/BUILD.bazel
+++ b/rpc/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "rpc",
+    srcs = [
+        "client.go",
+        "serialization.go",
+        "server.go",
+    ],
+    importpath = "checklist/rpc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_rocketlaunchr_https_go//:https-go",
+        "@com_github_ugorji_go_codec//:codec",
+    ],
+)

--- a/safebrowsing/BUILD.bazel
+++ b/safebrowsing/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "safebrowsing",
+    srcs = [
+        "hash.go",
+        "safebrowsing.pb.go",
+    ],
+    importpath = "checklist/safebrowsing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto",
+        "@com_github_golang_protobuf//ptypes/duration",
+    ],
+)

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testing",
+    srcs = ["benchmark_trace.go"],
+    importpath = "checklist/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//driver",
+        "//pir",
+        "//updatable",
+        "@org_golang_x_crypto//curve25519",
+        "@tools_gotest//assert",
+    ],
+)

--- a/updatable/BUILD.bazel
+++ b/updatable/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "updatable",
+    srcs = [
+        "pir_updatable.go",
+        "pir_updatable_server.go",
+        "pir_waterfall.go",
+        "rice.go",
+    ],
+    importpath = "checklist/updatable",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pir",
+        "//safebrowsing",
+        "@com_github_elliotchance_orderedmap//:orderedmap",
+    ],
+)
+
+go_test(
+    name = "updatable_test",
+    srcs = [
+        "pir_updatable_test.go",
+        "rice_test.go",
+    ],
+    embed = [":updatable"],
+    deps = [
+        "//pir",
+        "//safebrowsing",
+        "@com_github_golang_protobuf//proto",
+        "@tools_gotest//assert",
+    ],
+)


### PR DESCRIPTION
* Add WORKSPACE.bazel file that declares all external bazel dependencies as well as external go repositories
* Add various BUILD.bazel files for building different subpackages of the repo
* All BUILD files as well as the go external repository are auto generated by gazelle
* After auto generation by gazelle, two important manual changes were needed:
  1. gazelle does not support aliasing in go.mod, hence we needed to manually rename ./modules/dpf-go to github.com/dkales/dpf-go in the appropriate rules in some BUILD.bazel files
  2. gazelle incorrectly configures cgo linkoptions in psetgmm, "-lstdc++" must be used instead of its static version